### PR TITLE
PPSYL-101 - Add is_payplug_test_mode_enabled twig function

### DIFF
--- a/src/ApiClient/PayPlugApiClientFactory.php
+++ b/src/ApiClient/PayPlugApiClientFactory.php
@@ -41,7 +41,8 @@ final class PayPlugApiClientFactory implements PayPlugApiClientFactoryInterface
 
     public function createForPaymentMethod(PaymentMethodInterface $paymentMethod): PayPlugApiClientInterface
     {
-        $gatewayConfig = $paymentMethod->getGatewayConfig();
+        $gatewayConfig = $paymentMethod->getGatewayConfig() ?? throw new \LogicException('Gateway config not found');
+
         $key = $gatewayConfig->getConfig()['secretKey'];
         $factoryName = $gatewayConfig->getFactoryName();
 

--- a/src/ApiClient/PayPlugApiClientFactory.php
+++ b/src/ApiClient/PayPlugApiClientFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PayPlug\SyliusPayPlugPlugin\ApiClient;
 
+use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 
@@ -34,6 +35,15 @@ final class PayPlugApiClientFactory implements PayPlugApiClientFactoryInterface
             }
             $key = $gatewayConfig->getConfig()['secretKey'];
         }
+
+        return new PayPlugApiClient($key, $factoryName, $this->cache);
+    }
+
+    public function createForPaymentMethod(PaymentMethodInterface $paymentMethod): PayPlugApiClientInterface
+    {
+        $gatewayConfig = $paymentMethod->getGatewayConfig();
+        $key = $gatewayConfig->getConfig()['secretKey'];
+        $factoryName = $gatewayConfig->getFactoryName();
 
         return new PayPlugApiClient($key, $factoryName, $this->cache);
     }

--- a/src/Twig/PayPlugExtension.php
+++ b/src/Twig/PayPlugExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PayPlug\SyliusPayPlugPlugin\Twig;
 
+use PayPlug\SyliusPayPlugPlugin\ApiClient\PayPlugApiClientFactory;
 use PayPlug\SyliusPayPlugPlugin\Checker\CanSaveCardCheckerInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Twig\Extension\AbstractExtension;
@@ -13,21 +14,33 @@ final class PayPlugExtension extends AbstractExtension
 {
     /** @var CanSaveCardCheckerInterface */
     private $canSaveCardChecker;
+    private PayPlugApiClientFactory $apiClientFactory;
 
-    public function __construct(CanSaveCardCheckerInterface $canSaveCardChecker)
-    {
+    public function __construct(
+        CanSaveCardCheckerInterface $canSaveCardChecker,
+        PayPlugApiClientFactory $apiClientFactory,
+    ) {
         $this->canSaveCardChecker = $canSaveCardChecker;
+        $this->apiClientFactory = $apiClientFactory;
     }
 
     public function getFunctions(): array
     {
         return [
             new TwigFunction('is_save_card_enabled', [$this, 'isSaveCardAllowed']),
+            new TwigFunction('is_payplug_live', [$this, 'isLive']),
         ];
     }
 
     public function isSaveCardAllowed(PaymentMethodInterface $paymentMethod): bool
     {
         return $this->canSaveCardChecker->isAllowed($paymentMethod);
+    }
+
+    public function isLive(PaymentMethodInterface $paymentMethod): bool
+    {
+        $client = $this->apiClientFactory->createForPaymentMethod($paymentMethod);
+
+        return (bool) ($client->getAccount()['is_live']);
     }
 }

--- a/src/Twig/PayPlugExtension.php
+++ b/src/Twig/PayPlugExtension.php
@@ -28,7 +28,7 @@ final class PayPlugExtension extends AbstractExtension
     {
         return [
             new TwigFunction('is_save_card_enabled', [$this, 'isSaveCardAllowed']),
-            new TwigFunction('is_payplug_live', [$this, 'isLive']),
+            new TwigFunction('is_payplug_test_mode_enabled', [$this, 'isTest']),
         ];
     }
 
@@ -37,10 +37,10 @@ final class PayPlugExtension extends AbstractExtension
         return $this->canSaveCardChecker->isAllowed($paymentMethod);
     }
 
-    public function isLive(PaymentMethodInterface $paymentMethod): bool
+    public function isTest(PaymentMethodInterface $paymentMethod): bool
     {
         $client = $this->apiClientFactory->createForPaymentMethod($paymentMethod);
 
-        return (bool) ($client->getAccount()['is_live']);
+        return ((bool) $client->getAccount()['is_live']) !== true;
     }
 }


### PR DESCRIPTION
Call `{{ is_payplug_test_mode_enabled(paymentMethod) }}` to know if a given payment method is configured as live or not for a payplug one. Useful later while loading iframe for integrated payment

![image](https://github.com/user-attachments/assets/8e2099b7-84ef-47ef-8113-b823bf0c4e78)
